### PR TITLE
Update `remote_deps()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .settings/
 inst/doc
 .httr-oauth
+.RData

--- a/R/deps.R
+++ b/R/deps.R
@@ -286,6 +286,31 @@ remote_deps <- function(pkg) {
   diff <- installed == available
   diff <- ifelse(!is.na(diff) & diff, CURRENT, BEHIND)
 
+  is_github_remote <- vapply(remote, inherits, logical(1), "github_remote")
+  installed[is_github_remote] <-
+    vapply(
+      package,
+      FUN = function(x)
+        as.character(packageVersion(x)),
+      character(1)
+    )
+  installed_version_github_remote <-
+    package_version(installed[is_github_remote])
+
+  version_deps <- rbind(parse_deps(pkg[["depends"]]),
+                        parse_deps(pkg[["imports"]]))
+  remote_version_deps <- subset(version_deps, name %in% package)
+  required_version_github_remote <-
+    package_version(remote_version_deps$version[is_github_remote])
+
+  is_behind <- installed_version_github_remote < required_version_github_remote
+  is_current <- installed_version_github_remote == required_version_github_remote
+  is_ahead <- installed_version_github_remote > required_version_github_remote
+
+  diff[is_github_remote][is_behind] <- BEHIND
+  diff[is_github_remote][is_current] <- CURRENT
+  diff[is_github_remote][is_ahead] <- CURRENT
+
   res <- structure(
     data.frame(
       package = package,

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -244,13 +244,21 @@ parse_git_repo <- function(path) {
 
 #' @export
 remote_package_name.github_remote <- function(remote, ...) {
+  remote_package_description.github_remote(remote)$Package
+}
+
+remote_package_version.github_remote <- function(remote, ...) {
+  remote_package_description.github_remote(remote)$Version
+}
+
+remote_package_description.github_remote <- function(remote) {
   tmp <- tempfile()
   on.exit(unlink(tmp))
   github_contents(remote,
                   content_path = "DESCRIPTION",
                   path_to_save = tmp)
 
-  read_dcf(tmp)$Package
+  read_dcf(tmp)
 }
 
 #' @export


### PR DESCRIPTION
- 기존 `remote_deps` 함수
  - 역할
    - `DESCRIPTION` 파일의 `Remotes` 항목을 읽고 이에 대응되는 `package_deps` object를 생성
  - 문제점
    - 설치된 패키지의 `SHA`와 remote 패키지의 `SHA`의 일치 여부만을 비교하여, 패키지의 설치 여부를 결정함
    - 즉, 설치된 패키지의 버전이 remote 패키지의 버전보다 높더라도, `SHA`가 다르기 때문에 remote 패키지를 설치하여, 결과적으로 시스템의 패키지 버전이 낮아지는 결과를 초래

- 개선 사항
  - `remote` object 중, 적어도 `github_remote` object에 대해서는 `DESCRIPTION` 파일에 명시된 version requirement를 기반으로 설치 실행 여부를 결정함
  - 즉, 현재 설치된 패키지의 버전이 Remote 패키지 버전보다 낮더라도, version requirement를 충족시키기만 한다면 설치를 진행하지 않음
